### PR TITLE
Refactor config interface, removing hardcoded values.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "css-js-loader": "^0.2.2",
     "css-loader": "^0.23.1",
     "extract-text-webpack-plugin": "^0.9.0",
+    "lodash": "^4.15.0",
     "postcss-import": "^7.1.0",
     "postcss-loader": "^0.8.0",
     "postcss-require": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "postcss-import": "^7.1.0",
     "postcss-loader": "^0.8.0",
     "postcss-require": "^0.1.0",
-    "precss": "^1.3.0",
     "style-loader": "^0.13.0",
     "webpack-partial": "^1.0.0"
   },

--- a/src/postcss.webpack.config.js
+++ b/src/postcss.webpack.config.js
@@ -1,4 +1,6 @@
-import partial from 'webpack-partial';
+import compose from 'lodash/fp/compose';
+import identity from 'lodash/fp/identity';
+import {loader, plugin, partial} from 'webpack-partial';
 
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
 
@@ -8,35 +10,37 @@ import cssimport from 'postcss-import';
 import constants from 'postcss-require';
 
 // Regular expression used to detect what kind of files to process.
-const IS_STYLE = /\.(scss|sass|css)$/;
+const IS_STYLE = /\.(scss|sass|css(\.js)?)$/;
 const IS_CSS_JS = /\.css\.js$/;
 
 /**
  * Convert a loader string and query object into a complete loader string.
- * @param {String} loader Name of loader.
+ * @param {String} loaderPath Module path of the loader.
  * @param {Object} query Parameters object.
  * @returns {String} Generated loader string with query.
  */
-const pack = (loader, query) => {
-  return `${loader}?${JSON.stringify(query)}`;
+const pack = (loaderPath, query) => {
+  return `${loaderPath}?${JSON.stringify(query)}`;
 };
 
 /**
- * Generate the correct `loader` object given the parameters.
- * @param {String} target The webpack target.
- * @param {Boolean} external Whether to generate external CSS files.
- * @param {Boolean} minimize Whether to compress generated CSS.
- * @param {String} loader Loader for processing the stylesheet into CSS.
+ * Generate the correct `loader` string given the parameters.
+ * @param {String} options.localIdentName CSS module class name format.
+ * @param {Boolean} options.external Whether to generate external CSS files.
+ * @param {Boolean} options.minimize Whether to compress generated CSS.
+ * @param {Boolean} options.modules Whether to generate css modules.
+ * @param {String} options.target The webpack target, `web`, `node`, etc.
  * @returns {String} Final loader.
  */
-const loaders = ({target, external, minimize, loader}) => {
+const cssLoaders = ({localIdentName, external, minimize, modules, target}) => {
   const config = {
-    modules: true,
     importLoaders: 1,
-    localIdentName: '[name]-[local]-[hash:base64:5]',
-    minimize: minimize,
     sourceMap: true,
+    localIdentName,
+    minimize,
+    modules,
   };
+  const postcssLoader = require.resolve('postcss-loader');
   const cssLoader = require.resolve('css-loader');
   const cssLocals = require.resolve('css-loader/locals');
   const styleLoader = require.resolve('style-loader');
@@ -44,104 +48,138 @@ const loaders = ({target, external, minimize, loader}) => {
     if (external) {
       return ExtractTextPlugin.extract(
         styleLoader,
-        `${pack(cssLoader, config)}!${loader}`
+        `${pack(cssLoader, config)}!${postcssLoader}`
       );
     }
-    return `${styleLoader}!${pack(cssLoader, config)}!${loader}`;
+    return `${styleLoader}!${pack(cssLoader, config)}!${postcssLoader}`;
   }
-  return `${pack(cssLocals, config)}!${loader}`;
+  return `${pack(cssLocals, config)}!${postcssLoader}`;
 };
 
+const cssJsLoader = loader({
+  name: 'css-js',
+  test: IS_CSS_JS,
+  loader: require.resolve('css-js-loader'),
+});
+
+/**
+ * Create a webpack config partial function that applies postcss-loader.
+ * @param {String|Boolean} options.extract Filename to extract css into. Provide
+ * a falsy value to disable external CSS file generation.
+ * @param {Boolean} options.minimize Whether to compress generated CSS.
+ * @param {Boolean} options.modules Whether to process CSS as modules.
+ * @param {String} options.localIdentName CSS module class name format.
+ * @returns {Function} A webpack config partial function.
+ */
+const postcssLoader = ({extract, minimize, modules, localIdentName}) =>
+  (config) => loader({
+    name: 'postcss',
+    test: IS_STYLE,
+    loader: cssLoaders({
+      target: config.target,
+      external: !!extract,
+      localIdentName,
+      minimize,
+      modules,
+    }),
+  })(config);
+
+/**
+ * Create a webpack config partial function that applies a postcss config.
+ * @param {Array|Object|Function} options.options A postcss-loader config.
+ * @param {Object} options.autoprefixer An autoprefixer config object.
+ * @returns {Function} A webpack config partial function.
+ */
+const postcssConfig = ({options, autoprefixer: autoprefixerConfig}) =>
+  (config) => partial(config, {
+    postcss(webpack) {
+      const config = typeof options === 'function' ? options(webpack) : options;
+      const normalized = Array.isArray(config) ? {plugins: config} : config;
+
+      return {
+        ...normalized,
+        plugins: [
+          cssimport({
+            // Make webpack acknowledge imported files.
+            onImport: (files) => files.forEach((dep) =>
+              webpack.addDependency(dep)),
+            resolve: (id, {basedir}) =>
+              webpack.resolveSync(basedir, id),
+          }),
+          constants({
+            require: (request, _, done) => {
+              webpack.loadModule(request, (err, source) => {
+                if (err) {
+                  done(err);
+                } else {
+                  let result = null;
+                  try {
+                    result = webpack.exec(source, request);
+                    // interop for ES6 modules
+                    if (result.__esModule && result.default) {
+                      result = result.default;
+                    }
+                  } catch (e) {
+                    done(e);
+                    return;
+                  }
+                  // Don't need to call `this.addDependency` since the
+                  // `loadModule` function takes care of it.
+                  done(null, result);
+                }
+              });
+            },
+          }),
+          ...normalized.plugins,
+          ...autoprefixerConfig ? [autoprefixer(autoprefixerConfig)] : [],
+        ],
+      };
+    },
+  });
+
+/**
+ * Create an ExtractTextPlugin webpack config partial function. The plugin is
+ * included only if `extract` is not falsy and the current build targets web.
+ *
+ * @param  {String} extract) Filename to extract css into.
+ * @returns {Function} A webpack config partial function.
+ */
+const extractPlugin = (extract) => (config) =>
+  !!extract && config.target === 'web'
+    ? plugin(new ExtractTextPlugin(extract))
+    : identity;
+
+/**
+ * Create a postcss webpack config partial function.
+ * @param {Array|Object|Function} options.options A postcss-loader config.
+ * @param {String|Boolean} options.extract Filename to extract css into. Provide
+ * a falsy value to disable external CSS file generation.
+ * @param {Object} options.autoprefixer An autoprefixer config object.
+ * @param {Boolean} options.minimize Whether to compress generated CSS.
+ * @param {Boolean} options.modules Whether to process CSS as modules.
+ * @param {String} options.localIdentName CSS module class name format.
+ * @returns {Function} A webpack config partial function.
+ */
 export default ({
   options = [],
-  filename = '[name].css',
-} = {}) => (config) => {
-  const {target} = config;
-  const env = process.env.NODE_ENV || 'development';
-  const hot = process.env.HOT || false;
-  const production = env === 'production';
-
-  const external = (production || !hot) && target === 'web';
-  const minimize = production;
-
-  if (!Array.isArray(options) && typeof options !== 'function') {
-    throw new TypeError('`options` must be array or function!');
-  }
-
-  return partial(config, {
-    // Module settings.
-    module: {
-      loaders: [{
-        name: 'postcss',
-        test: IS_STYLE,
-        loader: loaders({
-          loader: require.resolve('postcss-loader'),
-          target,
-          external,
-          minimize,
-        }),
-      }, {
-        name: 'js-css',
-        test: IS_CSS_JS,
-        loader: loaders({
-          loader: [
-            require.resolve('postcss-loader'),
-            require.resolve('css-js-loader'),
-          ].join('!'),
-          target,
-          external,
-          minimize,
-        }),
-      }],
-    },
-
-    postcss(webpack) {
-      return [
-        cssimport({
-          // Make webpack acknowledge imported files.
-          onImport: (files) => files.forEach((dep) =>
-            webpack.addDependency(dep)),
-          resolve: (id, {basedir}) =>
-            webpack.resolveSync(basedir, id),
-        }),
-        constants({
-          require: (request, _, done) => {
-            webpack.loadModule(request, (err, source) => {
-              if (err) {
-                done(err);
-              } else {
-                let result = null;
-                try {
-                  result = webpack.exec(source, request);
-                  // interop for ES6 modules
-                  if (result.__esModule && result.default) {
-                    result = result.default;
-                  }
-                } catch (e) {
-                  done(e);
-                  return;
-                }
-                // Don't need to call `this.addDependency` since the
-                // `loadModule` function takes care of it.
-                done(null, result);
-              }
-            });
-          },
-        }),
-        ...(Array.isArray(options) ? options : options(webpack)),
-        autoprefixer({
-          browsers: ['last 2 versions'],
-        }),
-      ];
-    },
-
-    plugins: [
-      ...(external ? [
-        // Some crawlers or things with Javascript disabled prefer normal CSS
-        // instead of Javascript injected CSS, so this plugin allows for the
-        // collection of the generated CSS into its own file.
-        new ExtractTextPlugin(filename),
-      ] : []),
-    ],
-  });
-};
+  extract = process.env.NODE_ENV === 'production'
+    ? '[name].[hash].css'
+    : '[name].css',
+  autoprefixer = {
+    browsers: ['last 2 versions'],
+  },
+  minimize = process.env.NODE_ENV === 'production',
+  modules = true,
+  localIdentName = process.env.NODE_ENV === 'production'
+    ? '[hash:base64]'
+    : '[path]--[local]--[hash:base64:5]',
+} = {}) => compose(
+  // Add css-js-loader. This will feed parsed js styles into postcss-loader.
+  cssJsLoader,
+  // Add postcss-loader.
+  postcssLoader({extract, localIdentName, minimize, modules}),
+  // Add postcss-loader config.
+  postcssConfig({options, autoprefixer}),
+  // Add ExtractTextPlugin instance.
+  extractPlugin(!!extract)
+);

--- a/src/postcss.webpack.config.js
+++ b/src/postcss.webpack.config.js
@@ -4,7 +4,6 @@ import ExtractTextPlugin from 'extract-text-webpack-plugin';
 
 // `postcss` modules.
 import autoprefixer from 'autoprefixer';
-import precss from 'precss';
 import cssimport from 'postcss-import';
 import constants from 'postcss-require';
 
@@ -129,7 +128,6 @@ export default ({
             });
           },
         }),
-        precss,
         ...(Array.isArray(options) ? options : options(webpack)),
         autoprefixer({
           browsers: ['last 2 versions'],


### PR DESCRIPTION
The postcss config partial is now much more flexible with fewer hardcoded config values.

The `precss` plugin is no longer included by default.

The `postcss-loader` `options` config option can now be an object to provide additional configuration to `postcss`.

CSS module generation can be controlled with the `modules` option and the `localIdentName` option.

The `filename` option has been renamed to `extract`. A falsy value will disable external CSS file generation.

The included `autoprefixer` `postcss` plugin can be configured with the `autoprefixer` option. A falsy value will disable the `autoprefixer` plugin.

/cc @izaakschroeder
