### PR TITLE
Initial support for webpack@2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,29 +2,6 @@ sudo: false
 language: node_js
 matrix:
   include:
-    # Run tests in Node.js 0.12
-    - node_js: '0.12'
-
-    # Run tests in Node.js 4.x
-    - node_js: '4'
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-4.8
-            - g++-4.8
-
-    # Run tests in Node.js 5.x
-    - node_js: '5'
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-4.8
-            - g++-4.8
-
-before_install:
-  # Use GCC 4.8 if it's available
-  - 'if [ ! `which gcc-4.8` == "" ]; then export CXX=g++-4.8 && export CC=gcc-4.8; fi'
+    - node_js: 4
+    - node_js: 5
+    - node_js: 6

--- a/dist/postcss.webpack.config.js
+++ b/dist/postcss.webpack.config.js
@@ -1,0 +1,193 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _webpackPartial = require('webpack-partial');
+
+var _compose = require('lodash/fp/compose');
+
+var _compose2 = _interopRequireDefault(_compose);
+
+var _identity = require('lodash/fp/identity');
+
+var _identity2 = _interopRequireDefault(_identity);
+
+var _extractTextWebpackPlugin = require('extract-text-webpack-plugin');
+
+var _extractTextWebpackPlugin2 = _interopRequireDefault(_extractTextWebpackPlugin);
+
+var _autoprefixer = require('autoprefixer');
+
+var _autoprefixer2 = _interopRequireDefault(_autoprefixer);
+
+var _postcssImport = require('postcss-import');
+
+var _postcssImport2 = _interopRequireDefault(_postcssImport);
+
+var _postcssRequire = require('postcss-require');
+
+var _postcssRequire2 = _interopRequireDefault(_postcssRequire);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
+// `postcss` modules.
+
+
+// Regular expression used to detect what kind of files to process.
+var IS_STYLE = /\.(scss|sass|css)$/;
+var IS_CSS_JS = /\.css\.js$/;
+
+/**
+ * Generate the correct `loader` object given the parameters.
+ * @param {String} target The webpack target.
+ * @param {Boolean} external Whether to generate external CSS files.
+ * @param {Boolean} minimize Whether to compress generated CSS.
+ * @param {String} loader Loader for processing the stylesheet into CSS.
+ * @returns {String} Final loader.
+ */
+var loaders = function loaders(_ref) {
+  var target = _ref.target;
+  var external = _ref.external;
+  var minimize = _ref.minimize;
+  var _loaders = _ref.loaders;
+  var plugin = _ref.plugin;
+
+  var config = {
+    modules: true,
+    importLoaders: 1,
+    localIdentName: '[name]-[local]-[hash:base64:5]',
+    minimize: minimize,
+    sourceMap: true
+  };
+  var cssLoader = require.resolve('css-loader');
+  var cssLocals = require.resolve('css-loader/locals');
+  var styleLoader = require.resolve('style-loader');
+  if (target === 'web') {
+    if (external) {
+      return [plugin.loader({ omit: 1, remove: true }), {
+        loader: styleLoader
+      }, {
+        loader: cssLoader,
+        query: config
+      }].concat(_toConsumableArray(_loaders));
+    }
+    return [{
+      loader: styleLoader
+    }, {
+      loader: cssLoader,
+      query: config
+    }].concat(_toConsumableArray(_loaders));
+  }
+  return [{
+    loader: cssLocals,
+    query: config
+  }].concat(_toConsumableArray(_loaders));
+};
+
+exports.default = function () {
+  var _ref2 = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+  var _ref2$options = _ref2.options;
+  var options = _ref2$options === undefined ? [] : _ref2$options;
+  var _ref2$filename = _ref2.filename;
+  var filename = _ref2$filename === undefined ? '[name].css' : _ref2$filename;
+  return function (config) {
+    var _config$target = config.target;
+    var target = _config$target === undefined ? 'web' : _config$target;
+
+    var env = process.env.NODE_ENV || 'development';
+    var hot = process.env.HOT || false;
+    var production = env === 'production';
+
+    var external = (production || !hot) && target === 'web';
+    var minimize = production;
+
+    if (!Array.isArray(options) && typeof options !== 'function') {
+      throw new TypeError('`options` must be array or function!');
+    }
+
+    var postcss = function postcss(webpack) {
+      return [(0, _postcssImport2.default)({
+        // Make webpack acknowledge imported files.
+        onImport: function onImport(files) {
+          return files.forEach(function (dep) {
+            return webpack.addDependency(dep);
+          });
+        },
+        resolve: function resolve(id, basedir) {
+          return new Promise(function (resolve, reject) {
+            webpack.resolve(basedir, id, function (err, result) {
+              err ? reject(err) : resolve(result);
+            });
+          });
+        }
+      }), (0, _postcssRequire2.default)({
+        require: function require(request, _, done) {
+          webpack.loadModule(request, function (err, source) {
+            if (err) {
+              done(err);
+            } else {
+              var _result = null;
+              try {
+                _result = webpack.exec(source, request);
+                // interop for ES6 modules
+                if (_result.__esModule && _result.default) {
+                  _result = _result.default;
+                }
+              } catch (e) {
+                done(e);
+                return;
+              }
+              // Don't need to call `this.addDependency` since the
+              // `loadModule` function takes care of it.
+              done(null, _result);
+            }
+          });
+        }
+      })].concat(_toConsumableArray(Array.isArray(options) ? options : options(webpack)), [(0, _autoprefixer2.default)({
+        browsers: ['last 2 versions']
+      })]);
+    };
+
+    var extractor = new _extractTextWebpackPlugin2.default({ filename: filename });
+
+    var result = (0, _compose2.default)((0, _webpackPartial.loader)({
+      test: IS_STYLE,
+      loaders: loaders({
+        loaders: [{
+          loader: require.resolve('postcss-loader'),
+          query: { options: postcss }
+        }],
+        target: target,
+        external: external,
+        minimize: minimize,
+        plugin: extractor
+      })
+    }), (0, _webpackPartial.loader)({
+      test: IS_CSS_JS,
+      loaders: loaders({
+        loaders: [{
+          loader: require.resolve('postcss-loader'),
+          query: { options: postcss }
+        }, {
+          loader: require.resolve('css-js-loader')
+        }],
+        target: target,
+        external: external,
+        minimize: minimize,
+        plugin: extractor
+      })
+    }),
+    // Some crawlers or things with Javascript disabled prefer normal CSS
+    // instead of Javascript injected CSS, so this plugin allows for the
+    // collection of the generated CSS into its own file.
+    external ? (0, _webpackPartial.plugin)(extractor) : _identity2.default)(config);
+
+    return result;
+  };
+};
+//# sourceMappingURL=postcss.webpack.config.js.map

--- a/example/index.css
+++ b/example/index.css
@@ -1,3 +1,5 @@
+@import url("reset-css/reset.css");
+
 :global {
   html {
     background: red;

--- a/example/index.css
+++ b/example/index.css
@@ -1,0 +1,9 @@
+:global {
+  html {
+    background: red;
+  }
+}
+
+.foo {
+  background: green;
+}

--- a/example/index.css.js
+++ b/example/index.css.js
@@ -1,0 +1,7 @@
+
+module.exports = {
+  '.bar': {
+    color: 'green',
+    fontSize: 12,
+  },
+};

--- a/example/index.css.js
+++ b/example/index.css.js
@@ -1,4 +1,3 @@
-
 module.exports = {
   '.bar': {
     color: 'green',

--- a/example/index.js
+++ b/example/index.js
@@ -1,0 +1,9 @@
+/* eslint-disable no-var */
+/* eslint-disable import/no-require */
+/* eslint-disable no-console */
+
+var a = require('./index.css');
+var b = require('./index.css.js');
+
+console.log(a);
+console.log(b);

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -1,0 +1,19 @@
+/* eslint-disable no-var */
+/* eslint-disable import/no-require */
+
+var postcss = require('../').default;
+var path = require('path');
+
+module.exports = postcss()({
+  entry: './index.js',
+  context: __dirname,
+  output: {
+    path: path.join(__dirname, 'dist'),
+    publicPath: '/foo',
+    filename: 'bundle.js',
+  },
+  target: process.env.WEBPACK_TARGET,
+  resolveLoader: {
+    extensions: ['.js'],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "css-js-loader": "^0.2.2",
     "css-loader": "^0.25.0",
     "extract-text-webpack-plugin": "^2.0.0-beta.4",
+    "lodash": "^4.16.4",
     "postcss-import": "8.1.0",
     "postcss-loader": "^0.13.0",
     "postcss-require": "^0.1.0",
     "precss": "^1.3.0",
     "style-loader": "^0.13.1",
-    "webpack-partial": "^1.5.0"
+    "webpack-partial": "^2.0.0"
   },
   "peerDependencies": {
     "postcss": ">=5.0.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "extract-text-webpack-plugin": "izaakschroeder/extract-text-webpack-plugin#pass-proper-loader-options",
     "lodash": "^4.16.4",
     "postcss-import": "8.1.0",
-    "postcss-loader": "izaakschroeder/postcss-loader#options-via-query",
+    "postcss-loader": "postcss/postcss-loader",
     "postcss-require": "^0.1.0",
     "style-loader": "^0.13.1",
     "webpack-partial": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -17,12 +17,11 @@
     "autoprefixer": "^6.5.0",
     "css-js-loader": "^0.2.2",
     "css-loader": "^0.25.0",
-    "extract-text-webpack-plugin": "^2.0.0-beta.4",
+    "extract-text-webpack-plugin": "izaakschroeder/extract-text-webpack-plugin#pass-proper-loader-options",
     "lodash": "^4.16.4",
     "postcss-import": "8.1.0",
-    "postcss-loader": "^0.13.0",
+    "postcss-loader": "izaakschroeder/postcss-loader#options-via-query",
     "postcss-require": "^0.1.0",
-    "precss": "^1.3.0",
     "style-loader": "^0.13.1",
     "webpack-partial": "^2.0.0"
   },
@@ -38,6 +37,7 @@
     "eslint-plugin-import": "^0.12.1",
     "eslint-plugin-react": "^3.16.0",
     "postcss": "^5.2.4",
+    "reset-css": "^2.2.0",
     "webpack": "^2.1.0-beta.25"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,19 +8,22 @@
   "scripts": {
     "prepublish": "./node_modules/.bin/babel -s -d dist src",
     "lint": "./node_modules/.bin/eslint .",
-    "test": "npm run lint"
+    "smoke:web": "WEBPACK_TARGET=web ./node_modules/.bin/webpack --config ./example/webpack.config.js",
+    "smoke:node": "WEBPACK_TARGET=node ./node_modules/.bin/webpack --config ./example/webpack.config.js",
+    "smoke": "npm run smoke:web && npm run smoke:node",
+    "test": "npm run lint && npm run smoke"
   },
   "dependencies": {
-    "autoprefixer": "^6.0.3",
+    "autoprefixer": "^6.5.0",
     "css-js-loader": "^0.2.2",
-    "css-loader": "^0.23.1",
-    "extract-text-webpack-plugin": "^0.9.0",
-    "postcss-import": "^7.1.0",
-    "postcss-loader": "^0.8.0",
+    "css-loader": "^0.25.0",
+    "extract-text-webpack-plugin": "^2.0.0-beta.4",
+    "postcss-import": "8.1.0",
+    "postcss-loader": "^0.13.0",
     "postcss-require": "^0.1.0",
     "precss": "^1.3.0",
-    "style-loader": "^0.13.0",
-    "webpack-partial": "^1.0.0"
+    "style-loader": "^0.13.1",
+    "webpack-partial": "^1.5.0"
   },
   "peerDependencies": {
     "postcss": ">=5.0.0"
@@ -33,7 +36,7 @@
     "eslint-plugin-filenames": "^0.2.0",
     "eslint-plugin-import": "^0.12.1",
     "eslint-plugin-react": "^3.16.0",
-    "postcss": "^5.0.14",
-    "webpack": "^1.12.12"
+    "postcss": "^5.2.4",
+    "webpack": "^2.1.0-beta.25"
   }
 }

--- a/src/postcss.webpack.config.js
+++ b/src/postcss.webpack.config.js
@@ -124,7 +124,7 @@ export default ({
       loaders: loaders({
         loaders: [{
           loader: require.resolve('postcss-loader'),
-          query: {options: postcss},
+          query: {plugins: postcss},
         }],
         target,
         external,
@@ -137,7 +137,7 @@ export default ({
       loaders: loaders({
         loaders: [{
           loader: require.resolve('postcss-loader'),
-          query: {options: postcss},
+          query: {plugins: postcss},
         }, {
           loader: require.resolve('css-js-loader'),
         }],

--- a/src/postcss.webpack.config.js
+++ b/src/postcss.webpack.config.js
@@ -2,27 +2,17 @@ import {loader, plugin} from 'webpack-partial';
 import compose from 'lodash/fp/compose';
 import identity from 'lodash/fp/identity';
 
+import purdy from 'purdy';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
 
 // `postcss` modules.
 import autoprefixer from 'autoprefixer';
-import precss from 'precss';
 import cssimport from 'postcss-import';
 import constants from 'postcss-require';
 
 // Regular expression used to detect what kind of files to process.
 const IS_STYLE = /\.(scss|sass|css)$/;
 const IS_CSS_JS = /\.css\.js$/;
-
-/**
- * Convert a loader string and query object into a complete loader string.
- * @param {String} loader Name of loader.
- * @param {Object} query Parameters object.
- * @returns {String} Generated loader string with query.
- */
-const pack = (loader, query) => {
-  return `${loader}?${JSON.stringify(query)}`;
-};
 
 /**
  * Generate the correct `loader` object given the parameters.
@@ -32,7 +22,7 @@ const pack = (loader, query) => {
  * @param {String} loader Loader for processing the stylesheet into CSS.
  * @returns {String} Final loader.
  */
-const loaders = ({target, external, minimize, loader}) => {
+const loaders = ({target, external, minimize, loaders, plugin}) => {
   const config = {
     modules: true,
     importLoaders: 1,
@@ -45,14 +35,25 @@ const loaders = ({target, external, minimize, loader}) => {
   const styleLoader = require.resolve('style-loader');
   if (target === 'web') {
     if (external) {
-      return ExtractTextPlugin.extract({
-        fallbackLoader: styleLoader,
-        loader: `${pack(cssLoader, config)}!${loader}`,
-      });
+      return [plugin.loader({omit: 1, remove: true}), {
+        loader: styleLoader,
+      }, {
+        loader: cssLoader,
+        query: config,
+      },
+      ...loaders];
     }
-    return `${styleLoader}!${pack(cssLoader, config)}!${loader}`;
+    return [{
+      loader: styleLoader,
+    }, {
+      loader: cssLoader,
+      query: config,
+    }, ...loaders];
   }
-  return `${pack(cssLocals, config)}!${loader}`;
+  return [{
+    loader: cssLocals,
+    query: config,
+  }, ...loaders];
 };
 
 export default ({
@@ -77,8 +78,13 @@ export default ({
         // Make webpack acknowledge imported files.
         onImport: (files) => files.forEach((dep) =>
           webpack.addDependency(dep)),
-        resolve: (id, {basedir}) =>
-          webpack.resolveSync(basedir, id),
+        resolve: (id, basedir) => {
+          return new Promise((resolve, reject) => {
+            webpack.resolve(basedir, id, (err, result) => {
+              err ? reject(err) : resolve(result);
+            });
+          });
+        },
       }),
       constants({
         require: (request, _, done) => {
@@ -104,7 +110,6 @@ export default ({
           });
         },
       }),
-      precss,
       ...(Array.isArray(options) ? options : options(webpack)),
       autoprefixer({
         browsers: ['last 2 versions'],
@@ -112,33 +117,42 @@ export default ({
     ];
   };
 
-  return compose(
+  const extractor = new ExtractTextPlugin({filename});
+
+  const result = compose(
     loader({
       test: IS_STYLE,
-      loader: loaders({
-        loader: require.resolve('postcss-loader'),
+      loaders: loaders({
+        loaders: [{
+          loader: require.resolve('postcss-loader'),
+          query: {options: postcss},
+        }],
         target,
         external,
         minimize,
+        plugin: extractor,
       }),
-      query: postcss,
     }),
     loader({
       test: IS_CSS_JS,
-      loader: loaders({
-        loader: [
-          require.resolve('postcss-loader'),
-          require.resolve('css-js-loader'),
-        ].join('!'),
+      loaders: loaders({
+        loaders: [{
+          loader: require.resolve('postcss-loader'),
+          query: {options: postcss},
+        }, {
+          loader: require.resolve('css-js-loader'),
+        }],
         target,
         external,
         minimize,
+        plugin: extractor,
       }),
-      query: postcss,
     }),
     // Some crawlers or things with Javascript disabled prefer normal CSS
     // instead of Javascript injected CSS, so this plugin allows for the
     // collection of the generated CSS into its own file.
-    external ? plugin(new ExtractTextPlugin({filename})) : identity
+    external ? plugin(extractor) : identity
   )(config);
+
+  return result;
 };

--- a/src/postcss.webpack.config.js
+++ b/src/postcss.webpack.config.js
@@ -2,7 +2,6 @@ import {loader, plugin} from 'webpack-partial';
 import compose from 'lodash/fp/compose';
 import identity from 'lodash/fp/identity';
 
-import purdy from 'purdy';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
 
 // `postcss` modules.


### PR DESCRIPTION
This is obviously a breaking change because of the changes to the webpack API. Smoke tests have been added to ensure it works in the most basic of cases. `postcss-import` is pinned to `8.1.0` because of a breaking bug with `webpack@2`. See: https://github.com/postcss/postcss-import/issues/207.

With `webpack@2` locking down properties on the `loader` object it's no longer possible to merge "same" loaders with `webpack-partial`.

Support for `node@0.12` is removed because `webpack@2` does not support it.

See:
- https://github.com/webpack/extract-text-webpack-plugin/pull/266
- https://github.com/postcss/postcss-loader/pull/104

/cc @nealgranger @baer 
